### PR TITLE
Update shell.go

### DIFF
--- a/shell.go
+++ b/shell.go
@@ -94,11 +94,12 @@ func streamReader(stream io.Reader, boundary string, buffer *string, signal *syn
 	output := ""
 	bufsize := 64
 	marker := boundary + newline
-
+        defer signal.Done()
 	for {
 		buf := make([]byte, bufsize)
 		read, err := stream.Read(buf)
 		if err != nil {
+			*buffer = strings.TrimSuffix(output, marker)
 			return err
 		}
 
@@ -110,8 +111,6 @@ func streamReader(stream io.Reader, boundary string, buffer *string, signal *syn
 	}
 
 	*buffer = strings.TrimSuffix(output, marker)
-	signal.Done()
-
 	return nil
 }
 


### PR DESCRIPTION
PI-23122 : RSE script not returning metric values + Monitor already running error seen in Agent log
Description : If power-shell script having exit statement then getting EOF error and then returning from function but not handling properly "signal.Done()" cause script getting hang. so i changed "signal.Done()" to "defer signal.Done()".